### PR TITLE
Intensity blending/clamping functionality.

### DIFF
--- a/src/plasio_ui/history.cljs
+++ b/src/plasio_ui/history.cljs
@@ -15,6 +15,8 @@
    [[:camera :max-distance] "cmd"]
    [[:ro :point-size] "ps"]
    [[:ro :point-size-attenuation] "pa"]
+   [[:ro :intensity-blend] "ib"]
+   [[:ro :intensity-clamps] "ic"]
    [[:po :distance-hint] "dh"]
    [[:po :max-depth-reduction-hint] "mdr"]])
 

--- a/src/plasio_ui/widgets.cljs
+++ b/src/plasio_ui/widgets.cljs
@@ -1,5 +1,6 @@
 (ns plasio-ui.widgets
-  (:require [reagent.core :as reagent]))
+  (:require [reagent.core :as reagent]
+            [clojure.string :as string]))
 
 (defn panel
   "A simple widget which shows a panel with title and children"
@@ -26,14 +27,21 @@
       {:component-did-mount
        (fn []
          (let [slider (js/jQuery (.getDOMNode this))
-               emit #(f (js/parseFloat (.val slider)))]
+               single? (number? start)
+               start (if single?
+                       start
+                       (apply array start))
+               emit #(f (let [value (.val slider)]
+                          (if single?
+                            (js/parseFloat value)
+                            (mapv js/parseFloat (string/split value #",")))))]
            (doto slider
              (.on "slide" emit)
              (.on "set" emit))
            (.noUiSlider slider
                         (js-obj
                           "start" start
-                          "connect" "lower"
+                          "connect" (if single? "lower" true)
                           "range" (js-obj "min" min
                                           "max" max)))))
 


### PR DESCRIPTION
Add dual slider capability to slider widget.  Add intensity blending/clamping functionality and push their state values into the URL state.  Dynamically determine color/intensity existence from `schema` call and determine whether to use in-band color or imagery overlay based on the result.
